### PR TITLE
Fix issue where couldn't POST with default activity props set

### DIFF
--- a/frontend/src/pages/Activities/AddActivity/AddActivity.tsx
+++ b/frontend/src/pages/Activities/AddActivity/AddActivity.tsx
@@ -77,7 +77,7 @@ const AddActivity = ({}: AddActivityProps) => {
                     }
                     const itemData = Object.fromEntries(
                         Object.entries(formData).filter(
-                            ([k, v]) => !Object.keys(activityData).includes(k),
+                            ([k, v]) => !Object.keys(activityData).map(k => k.toLowerCase()).includes(k.toLowerCase().replace('activity__','')),
                         ),
                     )
                     createActivityMutation.mutate(


### PR DESCRIPTION
Creating a new activity fails if the user enters in data for default fields (rating, finished, notes), with the message `"Additional properties are not allowed ('activity__Finished', 'activity__Notes', 'activity__Rating' were unexpected)"`.

I suspect this is the dumbest possible way to solve this problem, but it does let me make new entries with these fields filled out! 