### PR TITLE
Add video game item type

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -34,4 +34,22 @@ default_item_types = [
         },
         "activity_schema": False,
     },
+    {
+        "slug": "video_game",
+        "name": "Video Game",
+        "name_schema": "{{title}}",
+        "auto_complete_config": {},
+        "item_schema": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "title": "Title"},
+                "console": {"type": "string", "title": "Console"},
+                "series": {"type": "string", "title": "Series"},
+                "series_num": {"type": "number", "title": "Series #"},
+            },
+            "additionalProperties": False,
+            "required": ["title", "console"],
+        },
+        "activity_schema": False,
+    },
 ]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -84,7 +84,7 @@ const LoggedInRoot = () => {
     const { data: userSettings } = useUserSettings()
 
     const itemTypesInQuickMenu = useMemo(() => {
-        const includedSlugs = userSettings?.itemTypesInQuickMenu ?? ['book', 'movie']
+        const includedSlugs = userSettings?.itemTypesInQuickMenu ?? ['book', 'movie','video_game']
         const includedItemTypes = (itemTypes ?? []).filter(it => includedSlugs.includes(it.slug))
         return includedItemTypes
     }, [itemTypes, userSettings])

--- a/frontend/src/services/item_service.tsx
+++ b/frontend/src/services/item_service.tsx
@@ -1,4 +1,4 @@
-import { BookOutlined, VideoCameraOutlined } from '@ant-design/icons'
+import {BookOutlined, LaptopOutlined, VideoCameraOutlined} from '@ant-design/icons'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
 import { ReactNode } from 'react'
@@ -6,6 +6,7 @@ import { ReactNode } from 'react'
 export const ItemIconByItemType: Record<string, ReactNode> = {
     book: <BookOutlined />,
     movie: <VideoCameraOutlined />,
+    video_game: <LaptopOutlined />,
 }
 
 export interface Item {


### PR DESCRIPTION
Just experimenting a bit with adding item types. This is really brilliant. Perhaps video games are an uncontroversial one? 

One other thought: man, Ant's icons kinda suck, right? They're pretty limited? Would you consider using a different icon set? I used to default to Font Awesome but I assume there's something else nice out there in the many years since I chose that as my go-to.