### PR TITLE
fix: fix error when item name schema includes number

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -127,7 +127,7 @@ class Item(TimeStampedModel):
         name_fields = re.findall(self.name_template_regex, self.item_type.name_schema)
         name = self.item_type.name_schema
         for field in name_fields:
-            name = name.replace("{{" + field + "}}", self.info.get(field, ""))
+            name = name.replace("{{" + field + "}}", str(self.info.get(field, "")))
         return name
 
     def __str__(self) -> str:


### PR DESCRIPTION
I was getting a bug if one of the fields in my item name schema was a number. This fixes it by just casting it to a string by default!