### PR TITLE
Item fields with spaces/dashes now render correctly from name schema

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -104,7 +104,7 @@ def _gen_item_token():
 
 
 class Item(TimeStampedModel):
-    name_template_regex = re.compile(r"{{([\w\.!%]+)}}")
+    name_template_regex = re.compile(r"{{([\w\-\.!%]+)}}")
     parent_stripper_regex = re.compile(r"(parent\.)*(.*)")
 
     token: "TextField[str, str]" = TextField(default=_gen_item_token, unique=True)


### PR DESCRIPTION
Prior to this change, any item type fields with a space in them wouldn't render correctly if that field was used in the item name schema (as seen in the example below):
![image](https://github.com/pinghedm/pillowbook/assets/10148380/5011d2b3-5933-40cc-b577-874e23be1295)

With this change, this is resolved, as the `-` is included in the regex:
![image](https://github.com/pinghedm/pillowbook/assets/10148380/92e727a6-a6bf-4627-a39e-a336a2884f7b)
